### PR TITLE
Remove duplicated code

### DIFF
--- a/plugins/stan/stan.plugin.zsh
+++ b/plugins/stan/stan.plugin.zsh
@@ -86,9 +86,6 @@ setopt autocd
 autoload -U promptinit
 promptinit
 
-# autocd
-setopt autocd
-
 # History
 export HISTFILE=~/.zsh_history
 export HISTSIZE=100000


### PR DESCRIPTION
The autocd option is already set in the plugin, see line 80. Thus as far as I can see there is no need to set it again.
Fixes #3 